### PR TITLE
Add robust tests for Profile setters/getters and command handlers

### DIFF
--- a/src/test/java/seedu/duke/CommandHandlerTest.java
+++ b/src/test/java/seedu/duke/CommandHandlerTest.java
@@ -317,4 +317,130 @@ class CommandHandlerTest {
         ch.handleRatio(inFull);
         assertEquals(new BigDecimal("1.0"), profile.getContributionRatio());
     }
+
+    void handleSavings_zeroDeposit_savingsUnchanged() {
+        profile.setCurrentSavings(new BigDecimal("1000.00"));
+        Scanner in = new Scanner(new ByteArrayInputStream("0\n".getBytes()));
+        ch.handleSavings(in);
+        assertEquals(new BigDecimal("1000.00"), profile.getCurrentSavings());
+    }
+
+    @Test
+    void handleSavings_fromZeroSavings_setsToDepositAmount() {
+        // default savings is 0; depositing 750.50 should result in exactly 750.50
+        Scanner in = new Scanner(new ByteArrayInputStream("750.50\n".getBytes()));
+        ch.handleSavings(in);
+        assertEquals(new BigDecimal("750.50"), profile.getCurrentSavings());
+    }
+
+    @Test
+    void handleSavings_invalidInputThenValid_updatesProfile() {
+        // "abc" fails the readMoney regex, loops; "200.00" is then accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("abc\n200.00\n".getBytes()));
+        ch.handleSavings(in);
+        assertEquals(new BigDecimal("200.00"), profile.getCurrentSavings());
+    }
+
+    @Test
+    void handleSavings_negativeInputThenValid_updatesProfile() {
+        // "-500" fails the readMoney regex (no leading digit pattern match), loops; "500.00" accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("-500\n500.00\n".getBytes()));
+        ch.handleSavings(in);
+        assertEquals(new BigDecimal("500.00"), profile.getCurrentSavings());
+    }
+
+    @Test
+    void handleSavings_multipleDeposits_accumulatesCorrectly() {
+        profile.setCurrentSavings(new BigDecimal("100.00"));
+        Scanner in1 = new Scanner(new ByteArrayInputStream("50.00\n".getBytes()));
+        ch.handleSavings(in1);
+        Scanner in2 = new Scanner(new ByteArrayInputStream("25.00\n".getBytes()));
+        ch.handleSavings(in2);
+        assertEquals(new BigDecimal("175.00"), profile.getCurrentSavings());
+    }
+
+    @Test
+    void handleAllowance_zeroAllowance_updatesProfile() {
+        Scanner in = new Scanner(new ByteArrayInputStream("0\n".getBytes()));
+        ch.handleAllowance(in);
+        assertEquals(new BigDecimal("0"), profile.getMonthlyAllowance());
+    }
+
+    @Test
+    void handleAllowance_largeValue_updatesProfile() {
+        Scanner in = new Scanner(new ByteArrayInputStream("99999.99\n".getBytes()));
+        ch.handleAllowance(in);
+        assertEquals(new BigDecimal("99999.99"), profile.getMonthlyAllowance());
+    }
+
+    @Test
+    void handleAllowance_invalidInputThenValid_updatesProfile() {
+        // "hello" fails regex, loops; "2000.00" is accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("hello\n2000.00\n".getBytes()));
+        ch.handleAllowance(in);
+        assertEquals(new BigDecimal("2000.00"), profile.getMonthlyAllowance());
+    }
+
+    @Test
+    void handleAllowance_negativeInputThenValid_updatesProfile() {
+        // "-100" fails the readMoney regex, loops; "100.00" is accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("-100\n100.00\n".getBytes()));
+        ch.handleAllowance(in);
+        assertEquals(new BigDecimal("100.00"), profile.getMonthlyAllowance());
+    }
+
+    @Test
+    void handleAllowance_tooManyDecimalsThenValid_updatesProfile() {
+        // "1000.555" fails regex (max 2 dp), loops; "1000.55" is accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("1000.555\n1000.55\n".getBytes()));
+        ch.handleAllowance(in);
+        assertEquals(new BigDecimal("1000.55"), profile.getMonthlyAllowance());
+    }
+
+    @Test
+    void handleRatio_twoDecimalPlaces_updatesProfile() {
+        Scanner in = new Scanner(new ByteArrayInputStream("0.75\n".getBytes()));
+        ch.handleRatio(in);
+        assertEquals(new BigDecimal("0.75"), profile.getContributionRatio());
+    }
+
+    @Test
+    void handleRatio_outOfRangeThenValid_updatesProfile() {
+        // "1.5" passes the regex format but value > 1, loops; "0.4" is accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("1.5\n0.4\n".getBytes()));
+        ch.handleRatio(in);
+        assertEquals(new BigDecimal("0.4"), profile.getContributionRatio());
+    }
+
+    @Test
+    void handleRatio_invalidFormatThenValid_updatesProfile() {
+        // "-0.5" fails regex (no leading digit), loops; "0.5" is accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("-0.5\n0.5\n".getBytes()));
+        ch.handleRatio(in);
+        assertEquals(new BigDecimal("0.5"), profile.getContributionRatio());
+    }
+
+    @Test
+    void handleRatio_tooManyDecimalsThenValid_updatesProfile() {
+        // "0.555" fails regex (3 dp), loops; "0.55" is accepted
+        Scanner in = new Scanner(new ByteArrayInputStream("0.555\n0.55\n".getBytes()));
+        ch.handleRatio(in);
+        assertEquals(new BigDecimal("0.55"), profile.getContributionRatio());
+    }
+
+    @Test
+    void handleRatio_withHousePriceSet_recalculatesBtoGoal() {
+        profile.setHousePrice(new BigDecimal("400000"));
+        Scanner in = new Scanner(new ByteArrayInputStream("0.5\n".getBytes()));
+        ch.handleRatio(in);
+        assertEquals(new BigDecimal("10500.00"), profile.getBtoGoal());
+    }
+
+    @Test
+    void handleRatio_withHousePriceSet_recalculatesBtoGoal_fullShare() {
+        profile.setHousePrice(new BigDecimal("400000"));
+        Scanner in = new Scanner(new ByteArrayInputStream("1.0\n".getBytes()));
+        ch.handleRatio(in);
+        assertEquals(new BigDecimal("21000.00"), profile.getBtoGoal());
+    }
 }

--- a/src/test/java/seedu/duke/CommandHandlerTest.java
+++ b/src/test/java/seedu/duke/CommandHandlerTest.java
@@ -437,7 +437,7 @@ class CommandHandlerTest {
     }
 
     @Test
-    void handleRatio_withHousePriceSet_recalculatesBtoGoal_fullShare() {
+    void handleRatio_withHousePriceSet_fullShare() {
         profile.setHousePrice(new BigDecimal("400000"));
         Scanner in = new Scanner(new ByteArrayInputStream("1.0\n".getBytes()));
         ch.handleRatio(in);

--- a/src/test/java/seedu/duke/data/ProfileTest.java
+++ b/src/test/java/seedu/duke/data/ProfileTest.java
@@ -3,6 +3,7 @@ package seedu.duke.data;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,12 +17,42 @@ public class ProfileTest {
         profile = new Profile();
     }
 
+    /**
+     * Unit tests for Allowance.
+     */
     @Test
     public void monthlyAllowance_setAndGet_correctValueStored() {
         BigDecimal testAllowance = new BigDecimal("5000.50");
         profile.setMonthlyAllowance(testAllowance);
         assertEquals(testAllowance, profile.getMonthlyAllowance());
     }
+
+    @Test
+    public void setMonthlyAllowance_null_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setMonthlyAllowance(null));
+    }
+
+    @Test
+    public void setMonthlyAllowance_zero_isAccepted() {
+        profile.setMonthlyAllowance(BigDecimal.ZERO);
+        assertEquals(BigDecimal.ZERO, profile.getMonthlyAllowance());
+    }
+
+    @Test
+    public void setMonthlyAllowance_largeValue_correctlyStored() {
+        BigDecimal large = new BigDecimal("99999.99");
+        profile.setMonthlyAllowance(large);
+        assertEquals(large, profile.getMonthlyAllowance());
+    }
+
+    @Test
+    public void monthlyAllowance_negativeValue_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setMonthlyAllowance(new BigDecimal("-100")));
+    }
+
+    /**
+     * Unit tests for Savings.
+     */
 
     @Test
     public void currentSavings_setAndGet_correctValueStored() {
@@ -31,6 +62,28 @@ public class ProfileTest {
     }
 
     @Test
+    public void setCurrentSavings_null_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setCurrentSavings(null));
+    }
+
+    @Test
+    public void setCurrentSavings_zero_isAccepted() {
+        profile.setCurrentSavings(BigDecimal.ZERO);
+        assertEquals(BigDecimal.ZERO, profile.getCurrentSavings());
+    }
+
+    @Test
+    public void setCurrentSavings_largeValue_correctlyStored() {
+        BigDecimal large = new BigDecimal("999999999.99");
+        profile.setCurrentSavings(large);
+        assertEquals(large, profile.getCurrentSavings());
+    }
+
+    /**
+     * Unit tests for contributionRatio.
+     */
+
+    @Test
     public void contributionRatio_setAndGet_correctValueStored() {
         BigDecimal testRatio = new BigDecimal("0.60");
         profile.setContributionRatio(testRatio);
@@ -38,20 +91,38 @@ public class ProfileTest {
     }
 
     @Test
+    public void setContributionRatio_null_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setContributionRatio(null));
+    }
+
+    @Test
+    public void setContributionRatio_negative_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setContributionRatio(new BigDecimal("-0.1")));
+    }
+
+    @Test
+    public void setContributionRatio_zero_isAccepted() {
+        profile.setContributionRatio(BigDecimal.ZERO);
+        assertEquals(BigDecimal.ZERO, profile.getContributionRatio());
+    }
+
+    @Test
+    public void setContributionRatio_one_isAccepted() {
+        profile.setContributionRatio(BigDecimal.ONE);
+        assertEquals(BigDecimal.ONE, profile.getContributionRatio());
+    }
+
+    @Test
+    public void setContributionRatio_withoutHousePrice_doesNotRecalculateBtoGoal() {
+        // housePrice is null on a fresh profile, so setContributionRatio must not touch btoGoal
+        profile.setBtoGoal(new BigDecimal("50000"));
+        profile.setContributionRatio(new BigDecimal("0.7"));
+        assertEquals(new BigDecimal("50000"), profile.getBtoGoal());
+    }
+
+    @Test
     public void contributionRatio_invalidValue_throwsAssertionError() {
         assertThrows(AssertionError.class, () -> profile.setContributionRatio(new BigDecimal("1.1")));
-    }
-
-    @Test
-    public void monthlyAllowance_negativeValue_throwsAssertionError() {
-        assertThrows(AssertionError.class, () -> profile.setMonthlyAllowance(new BigDecimal("-100")));
-    }
-
-    @Test
-    public void setHousePrice_validValue_updatesAttribute() {
-        BigDecimal price = new BigDecimal("500000");
-        profile.setHousePrice(price);
-        assertEquals(price, profile.getHousePrice());
     }
 
     @Test
@@ -65,8 +136,148 @@ public class ProfileTest {
         assertEquals(new BigDecimal("21000.00"), profile.getBtoGoal());
     }
 
+    /**
+     * Unit tests for housePrice.
+     */
+
+    @Test
+    public void setHousePrice_validValue_updatesAttribute() {
+        BigDecimal price = new BigDecimal("500000");
+        profile.setHousePrice(price);
+        assertEquals(price, profile.getHousePrice());
+    }
+
+    @Test
+    public void setHousePrice_null_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setHousePrice(null));
+    }
+
+    @Test
+    public void setHousePrice_zero_isAccepted() {
+        profile.setHousePrice(BigDecimal.ZERO);
+        assertEquals(BigDecimal.ZERO, profile.getHousePrice());
+    }
+
     @Test
     public void setHousePrice_negativeValue_throwsAssertionError() {
         assertThrows(AssertionError.class, () -> profile.setHousePrice(new BigDecimal("-1")));
+    }
+
+    /**
+     * Unit tests for btoGoal.
+     */
+
+    @Test
+    public void setBtoGoal_null_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setBtoGoal(null));
+    }
+
+    @Test
+    public void setBtoGoal_negativeValue_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setBtoGoal(new BigDecimal("-1")));
+    }
+
+    @Test
+    public void setBtoGoal_validValue_correctlyStored() {
+        BigDecimal goal = new BigDecimal("25000.00");
+        profile.setBtoGoal(goal);
+        assertEquals(goal, profile.getBtoGoal());
+    }
+
+    @Test
+    public void getBtoGoal_freshProfile_isZero() {
+        assertEquals(BigDecimal.ZERO, profile.getBtoGoal());
+    }
+
+    /**
+     * Unit tests for name.
+     */
+
+    @Test
+    public void setName_null_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setName(null));
+    }
+
+    @Test
+    public void setName_validName_correctlyStored() {
+        profile.setName("Adam");
+        assertEquals("Adam", profile.getName());
+    }
+
+    @Test
+    public void getName_freshProfile_returnsDefaultFriend() {
+        assertEquals("friend", profile.getName());
+    }
+
+    /**
+     * Unit tests for deadline.
+     */
+
+    @Test
+    public void setDeadline_null_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setDeadline(null));
+    }
+
+    @Test
+    public void setDeadline_pastDate_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setDeadline(LocalDate.of(2020, 1, 1)));
+    }
+
+    @Test
+    public void setDeadline_today_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setDeadline(LocalDate.now()));
+    }
+
+    @Test
+    public void setDeadline_futureDate_correctlyStored() {
+        LocalDate future = LocalDate.now().plusYears(2);
+        profile.setDeadline(future);
+        assertEquals(future, profile.getDeadline());
+    }
+
+    /**
+     * Unit tests for currentMonth and advanceMonth.
+     */
+
+    @Test
+    public void getCurrentMonth_freshProfile_isOne() {
+        assertEquals(1, profile.getCurrentMonth());
+    }
+
+    @Test
+    public void advanceMonth_once_isTwo() {
+        profile.advanceMonth();
+        assertEquals(2, profile.getCurrentMonth());
+    }
+
+    @Test
+    public void advanceMonth_multipleTimes_correctCount() {
+        profile.advanceMonth();
+        profile.advanceMonth();
+        profile.advanceMonth();
+        assertEquals(4, profile.getCurrentMonth());
+    }
+
+    /**
+     * Unit tests for reset.
+     */
+
+    @Test
+    public void reset_afterModifications_resetsAllFieldsToDefaults() {
+        profile.setName("Adam");
+        profile.setCurrentSavings(new BigDecimal("10000"));
+        profile.setMonthlyAllowance(new BigDecimal("2000"));
+        profile.setBtoGoal(new BigDecimal("50000"));
+        profile.setContributionRatio(new BigDecimal("0.7"));
+        profile.advanceMonth();
+
+        profile.reset();
+
+        assertEquals("friend", profile.getName());
+        assertEquals(BigDecimal.ZERO, profile.getCurrentSavings());
+        assertEquals(BigDecimal.ZERO, profile.getMonthlyAllowance());
+        assertEquals(BigDecimal.ZERO, profile.getBtoGoal());
+        assertEquals(new BigDecimal("0.5"), profile.getContributionRatio());
+        assertEquals(1, profile.getCurrentMonth());
     }
 }


### PR DESCRIPTION
  - Expand ProfileTest with happy/sad path coverage for currentSavings, monthlyAllowance, contributionRatio, housePrice, btoGoal, name, deadline, currentMonth, and reset
  - Expand CommandHandlerTest with sad/happy path coverage for handleSavings, handleAllowance, and handleRatio, including invalid input loop behaviour and btoGoal recalculation when housePrice is set