### PR TITLE
Update DG and UG for Profile management (allowance, ratio, savings, summary) 

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -232,6 +232,8 @@ to print month-grouped history and totals.
 
 ### Managing Profile
 
+![Class Diagram](diagram/Profile-ClassDiagram.png)
+
 The `Profile` class is the central data object for the user's financial identity. It stores the name,
 monthly allowance, current savings, BTO goal, contribution ratio, and target deadline. All other
 components — `CommandHandler`, `SummaryReport`, `BtoCalculator` — read from or write to it by reference.
@@ -266,6 +268,8 @@ runs `performInitialSetup()` before entering the command loop. The steps are:
 
 On subsequent launches, the saved profile is loaded from `fintrack.txt` and setup is skipped.
 
+![Sequence Diagram](diagram/ProfileSetup-SequenceDiagram.png)
+
 #### Runtime Profile Updates
 
 Three commands allow the user to update their profile after initial setup:
@@ -278,6 +282,8 @@ Three commands allow the user to update their profile after initial setup:
 
 All three handlers use `InputUtil.readMoney()` or `InputUtil.readRatio()` to enforce valid input,
 re-prompting the user on invalid entries rather than throwing an exception to the caller.
+
+![Sequence Diagram](diagram/ProfileRatio-SequenceDiagram.png)
 
 #### BTO Summary Report (`summary` command)
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -16,6 +16,7 @@ strategies employed in the development of FinTrackPro.
 * **3. [Design & Implementation](#3-design--implementation)**
   * **3.1 [Architecture Diagram](#31-architecture-diagram)**
   * **3.2 [UML Diagrams](#32-uml-diagrams)**
+    * **3.2.1 [Managing Profile](#managing-profile)**
 * **4. [Product Scope](#4-product-scope)**
   * **4.1 [Target user profile](#41-target-user-profile)**
   * **4.2 [Value proposition](#42-value-proposition)**
@@ -229,6 +230,57 @@ In the list flow, the user enters `list`, and FinTrackPro requests archive data 
 reads each MonthN file and reconstructs rows as List<ArchivedExpense>. FinTrackPro then iterates through these archived entries (name, amount, category)
 to print month-grouped history and totals.
 
+### Managing Profile
+
+The `Profile` class is the central data object for the user's financial identity. It stores the name,
+monthly allowance, current savings, BTO goal, contribution ratio, and target deadline. All other
+components — `CommandHandler`, `SummaryReport`, `BtoCalculator` — read from or write to it by reference.
+
+#### Initial Setup Flow
+
+When the application detects that no BTO goal has been set (i.e. the user is new), `FinTrackPro`
+runs `performInitialSetup()` before entering the command loop. The steps are:
+
+1. The user is prompted for their **name**.
+2. The user provides their **current savings** and **monthly allowance** (validated by `InputUtil.readMoney()`).
+3. The user provides the **total house price** and their **contribution ratio** (0.0–1.0, validated by `InputUtil.readRatio()`).
+4. `BtoCalculator` computes the **total downpayment** (2.5% of house price + 10% legal fees) and the
+   user's **personal share** (total downpayment × ratio). This value is stored in `Profile` as `btoGoal`.
+5. The user provides a **future deadline** (ISO `YYYY-MM-DD`, validated by `InputUtil.readFutureDate()`).
+6. The app displays the time remaining and the required monthly savings rate needed to meet the goal.
+
+On subsequent launches, the saved profile is loaded from `fintrack.txt` and setup is skipped.
+
+#### Runtime Profile Updates
+
+Three commands allow the user to update their profile after initial setup:
+
+| Command     | Handler             | Effect                                                                                          |
+|-------------|---------------------|-------------------------------------------------------------------------------------------------|
+| `allowance` | `handleAllowance()` | Replaces the stored monthly allowance with the new value entered by the user.                   |
+| `savings`   | `handleSavings()`   | Adds the entered amount to the current savings total (deposit, not replacement).                |
+| `ratio`     | `handleRatio()`     | Replaces the contribution ratio; automatically recalculates `btoGoal` if `housePrice` is set.  |
+
+All three handlers use `InputUtil.readMoney()` or `InputUtil.readRatio()` to enforce valid input,
+re-prompting the user on invalid entries rather than throwing an exception to the caller.
+
+#### BTO Summary Report (`summary` command)
+
+`handleSummary()` instantiates a `SummaryReport` from the current `Profile`, `ExpenseList`, and
+`RecurringExpenseList`. The report derives the following metrics at construction time:
+
+| Metric                   | Formula                                                                            |
+|--------------------------|------------------------------------------------------------------------------------|
+| Distance to goal         | `btoGoal − currentSavings`                                                         |
+| Monthly surplus          | `monthlyAllowance − (oneOffExpenses + recurringExpenses)`                          |
+| Percentage progress      | `(currentSavings / btoGoal) × 100`, capped at 100%                                |
+| Estimated months         | `distanceToGoal ÷ monthlySurplus` (only shown when surplus > 0 and goal not met)  |
+| Monthly required savings | `distanceToGoal ÷ monthsUntilDeadline`                                             |
+| Readiness level          | Mapped from percentage: ≥100% → Ready, ≥75% → Secure, ≥50% → On Track, ≥25% → Making Progress, else → Barely Started |
+
+The computed report is passed to `Ui.showSummaryReport()` for display. No data in `Profile` or
+`ExpenseList` is mutated by this command.
+
 # 4 Product Scope
 
 ## 4.1 Target user profile
@@ -338,7 +390,39 @@ An individual BTO budget planner for university students planning to apply for B
 ---
 
 ### Managing profile
-(to be added by Adam)
+
+1. **Updating monthly allowance**
+   1. Prerequisites: Application started and profile initialised.
+   2. Test case: Enter `allowance`, then enter `2000`. Expected: Allowance updated to $2,000.00 and confirmed.
+   3. Test case: Enter `allowance`, then enter `0`. Expected: Allowance set to $0.00 with no error.
+   4. Test case: Enter `allowance`, then enter `-100`. Expected: Error shown for negative value, user re-prompted.
+   5. Test case: Enter `allowance`, then enter `abc`. Expected: Error shown for non-numeric input, user re-prompted.
+   6. Test case: Enter `allowance`, then enter `100.123`. Expected: Error shown for more than 2 decimal places, user re-prompted.
+
+2. **Adding to savings**
+   1. Prerequisites: Application started and profile initialised.
+   2. Test case: Enter `savings`, then enter `500`. Expected: $500.00 added to existing savings; new total displayed.
+   3. Test case: Enter `savings`, then enter `0`. Expected: $0.00 added; savings total unchanged.
+   4. Test case: Enter `savings`, then enter `-50`. Expected: Error shown for negative value, user re-prompted.
+   5. Test case: Enter `savings`, then enter `abc`. Expected: Error shown for non-numeric input, user re-prompted.
+   6. Test case: Enter `savings`, then enter `100.999`. Expected: Error shown for more than 2 decimal places, user re-prompted.
+
+3. **Updating contribution ratio**
+   1. Prerequisites: Application started and house price set during initial setup.
+   2. Test case: Enter `ratio`, then enter `0.5`. Expected: Ratio set to 0.5; BTO goal recalculated and confirmed.
+   3. Test case: Enter `ratio`, then enter `0.0` or `1.0`. Expected: Boundary values accepted; BTO goal recalculated.
+   4. Test case: Enter `ratio`, then enter `1.5`. Expected: Error shown for value above 1.0, user re-prompted.
+   5. Test case: Enter `ratio`, then enter `-0.1`. Expected: Error shown for negative value, user re-prompted.
+   6. Test case: Enter `ratio`, then enter `abc`. Expected: Error shown for non-numeric input, user re-prompted.
+   7. Test case: Enter `ratio`, then enter `0.123`. Expected: Error shown for more than 2 decimal places, user re-prompted.
+
+4. **Viewing BTO Summary (`summary`)**
+   1. Prerequisites: Profile initialised with allowance, savings, BTO goal, and deadline all set.
+   2. Test case: Enter `summary` with current month expenses below monthly allowance. Expected: Summary shows positive monthly surplus and an estimated number of months to goal.
+   3. Test case: Enter `summary` after savings meet or exceed BTO goal. Expected: Summary shows 100% progress and a "goal achieved" message; no months estimate shown.
+   4. Test case: Enter `summary` when total expenses exceed monthly allowance. Expected: Summary shows negative surplus; a warning is shown instead of a months estimate.
+   5. Test case: Enter `summary` with no expenses recorded yet. Expected: Summary shows full BTO goal as distance-to-goal and the full monthly allowance as surplus.
+
 ---
 
 ### Reset and clear

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -236,6 +236,21 @@ The `Profile` class is the central data object for the user's financial identity
 monthly allowance, current savings, BTO goal, contribution ratio, and target deadline. All other
 components — `CommandHandler`, `SummaryReport`, `BtoCalculator` — read from or write to it by reference.
 
+#### BtoCalculator
+
+`BtoCalculator` encodes the HDB downpayment rules as a reusable calculation. Given a house price
+and contribution ratio, it computes two values at construction time:
+
+| Field              | Formula                                                        |
+|--------------------|----------------------------------------------------------------|
+| `totalDownpayment` | `housePrice × 0.025` (2.5% HDB downpayment) + 10% legal fees |
+| `yourShare`        | `totalDownpayment × contributionRatio`                         |
+
+Both values are rounded to 2 decimal places (HALF_UP). `yourShare` is stored in `Profile` as the
+user's `btoGoal` and is the target all savings progress is measured against. Calling
+`setContributionRatio()` on a `Profile` that already has a `housePrice` will silently re-run this
+calculation and update `btoGoal` in place.
+
 #### Initial Setup Flow
 
 When the application detects that no BTO goal has been set (i.e. the user is new), `FinTrackPro`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -17,51 +17,13 @@ FinTrack Pro was created for individual students in a relationship who are plann
 
 * <b>View all commands:</b> [help](#viewing-help-help)
 * <b>Add more savings:</b> [savings](#add-more-savings-savings)
+* <b>Update monthly allowance:</b> [allowance](#update-monthly-allowance-allowance)
+* <b>Update contribution ratio:</b> [ratio](#update-contribution-ratio-ratio)
 * <b>Adding an expense:</b> [add](#adding-an-expense-add)
 * <b>Listing all expenditures:</b> [list](#listing-all-entries-list)
 * <b>Sorting the expenditure list:</b> [sort](#sorting-the-expenditure-list-sort-keyword)
 * <b>Deleting an entry:</b> [delete](#deleting-an-entry-delete)
-* * <b>Deleting a recurring expense:</b> [deleterecurring](#deleting-a-recurring-entry-deleterecurring)
-* <b>Viewing financial summary:</b> [summary](#viewing-financial-summary-summary)
-* <b>Clearing all entries:</b> [clear](#clearing-all-entries-clear)
-* <b>Exiting the program:</b> [exit](#exiting-the-program-exit)
-* <b>Data Storage:</b> [storage](#data-storage)
-
-## Additional Help:
-* [FAQ](#faq)
-* [Command Summary](#command-summary)
-* [Enquiry](#enquiry)
-
-### Viewing Help: ```help ```
-Shows a message explaining how to access the help page, lists all commands. 
-
-<b>Format:</b> help <br>
-<b>Example of Usage:</b> <br>
-<b>Expected Output:</b>
-```
-help# FinTrackPro User Guide
-
-## Introduction
-
-FinTrack Pro was created for individual students in a relationship who are planning to set aside finances for their share of a BTO downpayment.
-
-## Quick Start
-1. Ensure that you have Java 17 or above installed.
-2. Down the latest ```.jar``` file of FinTrackPro from [here](https://github.com/AY2526S2-CS2113-T14-2/tP/releases).
-3. Copy the file to the folder that you want to use as the home folder for your Task Manager.
-4. Open Terminal(Mac) or Windows Powershell(Windows), ```cd``` into the folder you put the jar file in, and use the ```java -jar FinTrackPro.jar``` command to run the application. 
-5. You should see something an introduction page asking for your name. 
-6. Type the command in the command line and press Enter to execute it.
-7. You can refer to the [Features](#features-) page for details of each command. Have fun!!
-
-## Features 
-
-* <b>View all commands:</b> [help](#viewing-help-help)
-* <b>Add more savings:</b> [savings](#add-more-savings-savings)
-* <b>Adding an expense:</b> [add](#adding-an-expense-add)
-* <b>Listing all expenditures:</b> [list](#listing-all-entries-list)
-* <b>Sorting the expenditure list:</b> [sort](#sorting-the-expenditure-list-sort-keyword)
-* <b>Deleting an entry:</b> [delete](#deleting-an-entry-delete)
+* <b>Deleting a recurring expense:</b> [deleterecurring](#deleting-a-recurring-entry-deleterecurring)
 * <b>Viewing financial summary:</b> [summary](#viewing-financial-summary-summary)
 * <b>Clearing all entries:</b> [clear](#clearing-all-entries-clear)
 * <b>Exiting the program:</b> [exit](#exiting-the-program-exit)
@@ -111,6 +73,40 @@ Added: $1,000.00
 New total savings: $2,000.00
 ```
 
+### Update monthly allowance: ```allowance```
+Updates your monthly allowance to a new value.<br>
+<b>Format:</b> ```allowance``` <br>
+<b>Example of Usage:</b> ```allowance```<br>
+<b>Expected Output:</b>
+```
+allowance
+Current Monthly Allowance: $4,000.00
+Enter new monthly allowance:
+5000
+
+Success! Your monthly allowance is now $5,000.00
+```
+<b>NOTE:</b>
+- Amount must be a non-negative number with at most 2 decimal places.
+- This replaces the existing allowance (it does not add to it).
+
+### Update contribution ratio: ```ratio```
+Updates your share of the BTO downpayment cost relative to your partner.<br>
+<b>Format:</b> ```ratio``` <br>
+<b>Example of Usage:</b> ```ratio```<br>
+<b>Expected Output:</b>
+```
+ratio
+Current Contribution Ratio: 60.0% (0.6)
+Enter new ratio (0.0 to 1.0):
+0.5
+
+Success! Your contribution ratio is now 0.5
+```
+<b>NOTE:</b>
+- Value must be between `0.0` (0%) and `1.0` (100%), with at most 2 decimal places.
+- Updating the ratio automatically recalculates your BTO goal. Run `summary` to see the updated goal.
+
 ### Adding an expense: ```add ```
 Adds a regular expense to your monthly tracker, with optional field recurring.<br>
 <b>Format:</b> ```add <NAME> <AMOUNT> <CATEGORY> <RECURRING>``` <br>
@@ -125,9 +121,9 @@ Recurring Total: $30
 Added expense: [FOOD] breakfast $25
 Month 1 Total: $25
 ```
-<b>NOTE:</b>  
-- The keyword `recurring` is optional.  
-- If omitted, the expense will be treated as a one-off expense.  
+<b>NOTE:</b>
+- The keyword `recurring` is optional.
+- If omitted, the expense will be treated as a one-off expense.
 
 ### Listing all entries: ```list```
 Shows a list of current month expenses, categorized by month, and recurring or not recurring.<br>
@@ -284,212 +280,21 @@ Watch this space for more updates!!
 
 ## Command Summary
 
-| Action                 | Format, Examples                          |
-|------------------------|-------------------------------------------|
-| Viewing Help           | `help`                                    |
-| Add more savings       | `savings` e.g. `savings`                  |
-| Add Expense            | `add NAME AMOUNT CATEGORY [recurring]`    |
-| List Entries           | `list`                                    |
-| Delete Entry           | `delete INDEX` e.g. `delete 2`            |
-| Delete Recurring       | `deleterecurring INDEX`                   |
-| View Financial Summary | `summary`                                 |
-| Clear All Data         | `clear`                                   |
-| Exit Program           | `bye`                                     |
-
-### Enquiry
-We hope that you found FinTrackPro useful and easy to use!
-General Commands
-'help'    - view all current commands
-'summary' - generate your BTO readiness report based on your goals
-'bye'     - exit the program
-
-Daily Transaction Commands
-'add'      <name> <amount> <category> <recurring> - add a new expense
-(e.g., add lunch 5.50 FOOD for not recurring and add lunch 5.50 FOOD recurring for recurring)
-..
-..
-```
-
-
-### Add more savings: ```savings```
-Add more savings from the initial saving count
-
-<b>Format:</b> ```savings``` <br>
-<b>NOTE:</b> When entering `amount`, it represents the additional amount of cash you want to add towards the goal.<br>
-<b>Example of Usage:</b> ```savings```<br>
-<b>Expected Output:</b>
-```
-savings
-Current total savings: $1,000.00
-Enter amount to add to your savings:
-1000
-
-Transaction successful!
-Added: $1,000.00
-New total savings: $2,000.00
-```
-
-### Adding an expense: ```add ```
-Adds a regular expense to your monthly tracker, with optional field recurring.<br>
-<b>Format:</b> ```add <NAME> <AMOUNT> <CATEGORY> <RECURRING>``` <br>
-<b>Example of Usage:</b> <br>
-```add netflix 30 entertainment recurring ```<br>
-```add breakfast 25 food``` <br>
-<b>Expected Output:</b>
-```
-Added recurring expense: [RECURRING][ENTERTAINMENT] netflix $30
-Recurring Total: $30
-
-Added expense: [FOOD] breakfast $25
-Month 1 Total: $25
-```
-
-### Listing all entries: ```list```
-Shows a list of current month expenses, categorized by month, and recurring or not recurring.<br>
-<b>Format:</b> ```list``` <br>
-<b>Example of Usage:</b> ```list```<br>
-<b>Expected Output:</b>
-```
-Here are your recurring monthly commitments!
-1. netflix $30.00 [ENTERTAINMENT]
-
-*** MONTH 1 EXPENSES
-1. breakfast $25.00 [FOOD]
-Month 1 Total: $25.00
-```
-
-### Sorting the expenditure list: ```sort <keyword>```
-Sorts the expenditure list by category or by recency. Valid keywords are `category` and `recent`.<br>
-<b>Format:</b> ```sort category``` or ```sort recent```<br>
-<b>Example of Usage:</b> ```sort category```<br>
-<b>Expected Output:</b>
-```
-sort category
-Expenses sorted by category.
-
-sort recent
-Expenses sorted by insertion order.
-```
-<b>NOTE:</b> Use `list` after sorting to view the updated order. Any keyword other than `category` or `recent` will be rejected with an error message.
-
-### Deleting an entry: ```delete```
-Deletes the specified entry from the tracker.<br>
-<b>Format:</b> ```delete INDEX``` <br>
-<b>Example of Usage:</b> ```delete 1```<br>
-<b>Expected Output:</b>
-```
-delete 1
-Deleted expense #1: $30
-Current Total: $15.90
-```
-
-### Viewing financial summary: ```summary```
-Displays a comprehensive overview of your financial status, including distance to goal.<br>
-<b>Format:</b> ```summary``` <br>
-<b>Example of Usage:</b> ```summary```<br>
-<b>Expected Output:</b>
-```
-===== BTO Readiness Report =====
-User: nicholas
-BTO Goal: $12,285.00 (your share + fees)
-Deadline: 2027-08-06 (17 months)
-
-Current Savings: $1,000.00 (8% reached)
-Distance to Goal: $11,285.00
-
-Monthly Allowance: $4,000.00
-Total Expenditure: $30.00
-Monthly Surplus: $3,970.00
-Estimated Goal Achievement: 3 months
-```
-
-### Clearing all entries: ```clear```
-Deletes all current data and resets the profile<br>
-<b>Format:</b> ```clear``` <br>
-<b>Example of Usage:</b> ```clear```<br>
-<b>Expected Output:</b>
-```
-Are you sure you want to clear all current data? (Y/N):
-(if Y) You have cleared all current data!
-(else) Cancelling clearing data!
-```
-
-### Exiting the program: ```bye```
-Exits the program<br>
-<b>Format:</b> ```bye``` <br>
-<b>Example of Usage:</b> ```bye``` <br>
-<b>Expected Output:</b>
-```
-Goodbye nicholas. Stay disciplined and get that house that you always wanted!
-```
-
-### Archive monthly expenditures: ```save```
-Saves the current month of expenditures into monthly_archives, and resets the expenditure to 0, simulating a new month.<br>
-<b>Format:</b> ```save``` <br>
-<b>Example of Usage:</b> ```save``` <br>
-<b>Expected Output:</b>
-```
-Month 1 expenses archived to 'monthly_archives'
-Transferred $3,975.00 of unspent allowance to savings
-Advanced to Month 2
-Current Savings: $4,975.00
-Monthly Allowance: $4,000.00
-```
-
-### Data Storage
-Stores the data in relative path as 'fintrack.txt'<br>
-<b>NOTE:</b> The saving of data into storage will only be done after you type 'bye'<br>
-<b>Expected Output:</b>
-```
-P | nicholas | 4000 | 1000 | 12285.00 | 0.6 | 2027-08-06
-E | 30
-```
-
-**Below is a table for the interpretation of the output in** `fintrack.txt`
-
-**Profile**
-
-| Field        | Value              | Meaning                                               |
-|--------------|--------------------|-------------------------------------------------------|
-| `P`          | profile marker     | tells the viewer this line represents a **Profile**   |
-| `nicholas`   | name               | user's name                                           |
-| `4000`       | monthly allowance     | user earns **$4000/month**                            |
-| `1000`       | current savings    | currently saved **$1000**                             |
-| `12285.00`   | BTO goal           | amount needed for the **downpayment goal**            |
-| `0.6`        | contribution ratio | user is paying **60%** of the BTO cost                |
-| `2027-08-06` | deadline           | goal date (ISO format `YYYY-MM-DD`)                   |
-
-**Expenditure**
-
-| Field        | Value              | Meaning                                               |
-|--------------|--------------------|-------------------------------------------------------|
-| `E`          | expenditure        | tells the viewer this line represents **Expenditure** |
-| `30`         | amount             | user has spent **$30** on a single expenditure        |
-
-## FAQ
-<b>Updated as of 15 March 2026</b>
-
-**Q**: How do I transfer my data to another computer? 
-
-**A**: At this point you cannot, your data will be saved on your local device. Just run the code again and
-you should not have to restart all your progress!
-
-Watch this space for more updates!!
-
-## Command Summary
-
-| Action                 | Format, Examples               |
-|------------------------|--------------------------------|
-| Viewing Help           | `help`                         |
-| Add more savings       | `savings` e.g. `savings`       |
-| Add Expense            | `add AMOUNT` e.g. `add 450`    |
-| List Entries           | `list`                         |
-| Delete Entry           | `delete INDEX` e.g. `delete 2` |
-| View Financial Summary | `summary`                      |
-| Clear All Data         | `clear`                        |
-| Exit Program           | `bye`                          |
+| Action                    | Format, Examples                          |
+|---------------------------|-------------------------------------------|
+| Viewing Help              | `help`                                    |
+| Add more savings          | `savings`                                 |
+| Update monthly allowance  | `allowance`                               |
+| Update contribution ratio | `ratio`                                   |
+| Add Expense               | `add NAME AMOUNT CATEGORY [recurring]`    |
+| List Entries              | `list`                                    |
+| Delete Entry              | `delete INDEX` e.g. `delete 2`            |
+| Delete Recurring          | `deleterecurring INDEX`                   |
+| View Financial Summary    | `summary`                                 |
+| Clear All Data            | `clear`                                   |
+| Exit Program              | `bye`                                     |
 
 ### Enquiry
 We hope that you found FinTrackPro useful and easy to use!
 
-Meanwhile, if you have any enquires/bugs that you might have found please email us [here!](mailto:e1406324@u.nus.edu) 
+Meanwhile, if you have any enquires/bugs that you might have found please email us [here!](mailto:e1406324@u.nus.edu)

--- a/docs/diagram/Profile-ClassDiagram.puml
+++ b/docs/diagram/Profile-ClassDiagram.puml
@@ -1,0 +1,59 @@
+@startuml Profile-ClassDiagram
+
+skinparam classAttributeIconSize 0
+skinparam class {
+    BackgroundColor White
+    BorderColor Black
+    ArrowColor Black
+}
+
+class Profile {
+    - name : String
+    - monthlyAllowance : BigDecimal
+    - currentSavings : BigDecimal
+    - btoGoal : BigDecimal
+    - contributionRatio : BigDecimal
+    - housePrice : BigDecimal
+    - deadline : LocalDate
+    - currentMonth : int
+    + setContributionRatio(contributionRatio : BigDecimal) : void
+    + setHousePrice(housePrice : BigDecimal) : void
+    + setBtoGoal(btoGoal : BigDecimal) : void
+    + advanceMonth() : void
+    + reset() : void
+}
+
+class BtoCalculator {
+    + totalDownpayment : BigDecimal
+    + yourShare : BigDecimal
+    + BtoCalculator(housePrice : BigDecimal, ratio : BigDecimal)
+}
+
+class CommandHandler {
+    + handleAllowance(in : Scanner) : void
+    + handleSavings(in : Scanner) : void
+    + handleRatio(in : Scanner) : void
+    + handleSummary() : void
+}
+
+class SummaryReport {
+    + SummaryReport(profile : Profile,\n  expenseList : ExpenseList,\n  recurringExpenseList : RecurringExpenseList)
+}
+
+class Storage {
+    + save(profile : Profile, ...) : void
+    + load(profile : Profile, ...) : void
+}
+
+class FinTrackPro {
+    - performInitialSetup(in : Scanner) : String
+}
+
+Profile ..> BtoCalculator : <<creates>>\non ratio change
+
+CommandHandler --> Profile : updates
+FinTrackPro --> Profile : initialises
+SummaryReport ..> Profile : reads
+Storage ..> Profile : persists / loads
+
+@enduml

--- a/docs/diagram/ProfileRatio-SequenceDiagram.puml
+++ b/docs/diagram/ProfileRatio-SequenceDiagram.puml
@@ -1,0 +1,43 @@
+@startuml ProfileRatio-SequenceDiagram
+
+skinparam sequenceArrowThickness 1.5
+skinparam sequenceParticipantBorderColor Black
+skinparam sequenceParticipantBackgroundColor White
+skinparam sequenceLifeLineBorderColor Black
+skinparam sequenceArrowColor Black
+
+actor User
+participant FinTrackPro
+participant CommandHandler
+participant Ui
+participant InputUtil
+participant Profile
+participant BtoCalculator
+
+User -> FinTrackPro : "ratio"
+FinTrackPro -> CommandHandler : handleRatio(in)
+
+CommandHandler -> Profile : getContributionRatio()
+Profile --> CommandHandler : currentRatio
+
+CommandHandler -> Ui : promptForRatio(currentRatio)
+Ui --> User : "Current Contribution Ratio: X% (X.X)"
+
+CommandHandler -> InputUtil : readRatio(ui, in, prompt)
+User -> InputUtil : enter new ratio
+InputUtil --> CommandHandler : newRatio : BigDecimal
+
+CommandHandler -> Profile : setContributionRatio(newRatio)
+alt housePrice != null
+    create BtoCalculator
+    Profile -> BtoCalculator : new BtoCalculator(housePrice, newRatio)
+    BtoCalculator --> Profile : yourShare
+    Profile -> Profile : btoGoal = yourShare
+else housePrice is null
+    Profile -> Profile : ratio updated, btoGoal unchanged
+end
+
+CommandHandler -> Ui : printLine("Success! Your contribution ratio is now " + newRatio)
+Ui --> User : success message
+
+@enduml

--- a/docs/diagram/ProfileSetup-SequenceDiagram.puml
+++ b/docs/diagram/ProfileSetup-SequenceDiagram.puml
@@ -1,0 +1,57 @@
+@startuml ProfileSetup-SequenceDiagram
+
+skinparam sequenceArrowThickness 1.5
+skinparam sequenceParticipantBorderColor Black
+skinparam sequenceParticipantBackgroundColor White
+skinparam sequenceLifeLineBorderColor Black
+skinparam sequenceArrowColor Black
+
+actor User
+participant FinTrackPro
+participant Storage
+participant InputUtil
+participant Profile
+participant BtoCalculator
+
+User -> FinTrackPro : launch app
+FinTrackPro -> Storage : load(profile, expenseList, recurringExpenseList)
+Storage --> FinTrackPro : data loaded (or fresh start if file missing)
+FinTrackPro -> Profile : getBtoGoal()
+Profile --> FinTrackPro : 0 (no goal set)
+FinTrackPro -> FinTrackPro : performInitialSetup(in)
+
+User -> FinTrackPro : enter name
+FinTrackPro -> Profile : setName(name)
+
+FinTrackPro -> InputUtil : readMoney(ui, in, "savings prompt")
+User -> InputUtil : enter savings amount
+InputUtil --> FinTrackPro : savings : BigDecimal
+FinTrackPro -> Profile : setCurrentSavings(savings)
+
+FinTrackPro -> InputUtil : readMoney(ui, in, "allowance prompt")
+User -> InputUtil : enter monthly allowance
+InputUtil --> FinTrackPro : allowance : BigDecimal
+FinTrackPro -> Profile : setMonthlyAllowance(allowance)
+
+FinTrackPro -> InputUtil : readMoney(ui, in, "house price prompt")
+User -> InputUtil : enter house price
+InputUtil --> FinTrackPro : housePrice : BigDecimal
+FinTrackPro -> Profile : setHousePrice(housePrice)
+
+FinTrackPro -> InputUtil : readRatio(ui, in, "ratio prompt")
+User -> InputUtil : enter contribution ratio
+InputUtil --> FinTrackPro : ratio : BigDecimal
+FinTrackPro -> Profile : setContributionRatio(ratio)
+create BtoCalculator
+Profile -> BtoCalculator : new BtoCalculator(housePrice, ratio)
+BtoCalculator --> Profile : yourShare
+Profile -> Profile : btoGoal = yourShare
+
+FinTrackPro -> InputUtil : readFutureDate(ui, in, "deadline prompt")
+User -> InputUtil : enter deadline (YYYY-MM-DD)
+InputUtil --> FinTrackPro : deadline : LocalDate
+FinTrackPro -> Profile : setDeadline(deadline)
+
+FinTrackPro -> User : display time remaining\nand monthly savings needed
+
+@enduml

--- a/logs/fintrack.log
+++ b/logs/fintrack.log
@@ -780,3 +780,273 @@
 [2026-03-27 11:55:20] [INFO] seedu.duke.FinTrackPro - state=run.profile.new | expected=perform initial setup workflow | btoGoal=0
 [2026-03-27 11:55:20] [INFO] seedu.duke.FinTrackPro - state=setup.start | expected=collect name, finances and deadline | scannerReady=true
 [2026-03-27 11:55:20] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: What is your name?
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - Index string rejected | reason: Index string does not match integer format
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseDeleteIndex rejected | reason: index -1 out of range, list size: 0
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseAmount rejected | reason: negative value -1
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseAmount rejected | reason: more than 2 decimal places, value: 1200.555
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: lunch | amount: $3.00 | category: FOOD | new total: $3.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: bus fare | amount: $2.00 | category: TRANSPORT | new total: $5.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: movie | amount: $10.00 | category: ENTERTAINMENT | new total: $15.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: electricity | amount: $50.00 | category: UTILITIES | new total: $65.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: misc | amount: $1.00 | category: OTHER | new total: $66.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSavings executed | deposited: $750.50 | new savings total: $750.50
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 750.50, formatted: $750.50
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 750.50, formatted: $750.50
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: transport fare | amount: $5.00 | category: TRANSPORT | new total: $5.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: caifan lunch | amount: $4.00 | category: FOOD | new total: $9.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: movie | amount: $10.00 | category: ENTERTAINMENT | new total: $19.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: popcorn | amount: $6.00 | category: FOOD | new total: $25.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSort executed | sort type: category
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSort executed | sort type: recent
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleReset cancelled | user did not confirm
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAllowance executed | old: 0 | new: 1500.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 1500.00, formatted: $1,500.00
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseAmount rejected | reason: more than 2 decimal places, value: 7.009
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 0.7
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseDeleteIndex rejected | reason: empty input
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseAmount rejected | reason: non-numeric input 'hello'
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readRatio unsuccessful | reason: out of specified bounds
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 0.4
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: Hainanese Chicken Rice | amount: $6.50 | category: FOOD | new total: $6.50
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: lunch | amount: $10.50 | category: FOOD | new total: $10.50
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - handleAdd rejected | reason: insufficient arguments
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseDeleteIndex rejected | reason: index 2 out of range, list size: 0
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSaveMonth start | month=1 | monthlyAllowance=500 | oneOffExpenses=600 | recurringExpenses=0 | monthlyExpenses=600 | unspentAmount=-100
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /Users/adam/Coding/CS2113_TP/Team Project/tp/./monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 1one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - Month 1 expenses archived successfully
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - Overspent this month | deficit=100
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 100, formatted: $100.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - Expense list cleared for next month
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - Advanced to next month | currentMonth=2
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 1000, formatted: $1,000.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 500, formatted: $500.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readMoney unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAllowance executed | old: 0 | new: 100.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 100.00, formatted: $100.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAllowance executed | old: 0 | new: 0
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readMoney unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAllowance executed | old: 0 | new: 2000.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 2000.00, formatted: $2,000.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readRatio unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 0.55
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to fintrack.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleReset executed | All data cleared and save file overwritten
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: transport fare | amount: $5.00 | category: TRANSPORT | new total: $5.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: caifan lunch | amount: $4.00 | category: FOOD | new total: $9.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: movie | amount: $10.00 | category: ENTERTAINMENT | new total: $19.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: popcorn | amount: $6.00 | category: FOOD | new total: $25.00
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - handleSort rejected | unknown argument: 
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 100.00, formatted: $100.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSavings executed | deposited: $50.00 | new savings total: $150.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 50.00, formatted: $50.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 150.00, formatted: $150.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 150.00, formatted: $150.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSavings executed | deposited: $25.00 | new savings total: $175.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 25.00, formatted: $25.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 175.00, formatted: $175.00
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseAmount rejected | reason: empty input
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readMoney unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSavings executed | deposited: $500.00 | new savings total: $500.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 500.00, formatted: $500.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 500.00, formatted: $500.00
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - handleAdd rejected | reason: invalid category HELLO
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: transport fare | amount: $5.00 | category: TRANSPORT | new total: $5.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: caifan lunch | amount: $4.00 | category: FOOD | new total: $9.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: movie | amount: $10.00 | category: ENTERTAINMENT | new total: $19.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: popcorn | amount: $6.00 | category: FOOD | new total: $25.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSort executed | sort type: category
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - Index string rejected | reason: Index string does not match integer format
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseDeleteIndex rejected | reason: index -1 out of range, list size: 0
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 0.0
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.0 | new: 1.0
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readMoney unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSavings executed | deposited: $200.00 | new savings total: $200.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 200.00, formatted: $200.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 200.00, formatted: $200.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAllowance executed | old: 0 | new: 99999.99
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 99999.99, formatted: $99,999.99
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: LUNCH | amount: $5.00 | category: FOOD | new total: $5.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | recurring expense | name: Netflix Subscription | amount: $15.00 | category: ENTERTAINMENT
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 0.75
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: transport fare | amount: $5.00 | category: TRANSPORT | new total: $5.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: caifan lunch | amount: $4.00 | category: FOOD | new total: $9.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: movie | amount: $10.00 | category: ENTERTAINMENT | new total: $19.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAdd succeeded | name: popcorn | amount: $6.00 | category: FOOD | new total: $25.00
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - handleSort rejected | unknown argument: foo
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 1000.00, formatted: $1,000.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount to add to your savings:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleSavings executed | deposited: $500.00 | new savings total: $1500.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 500.00, formatted: $500.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 1500.00, formatted: $1,500.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readRatio unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 0.5
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 0.5
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleClear executed | all one-off expenses cleared by user confirmation
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new ratio (0.0 to 1.0):
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleRatio executed | old: 0.5 | new: 1.0
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readMoney unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter new monthly allowance:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - handleAllowance executed | old: 0 | new: 1000.55
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 1000.55, formatted: $1,000.55
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - parseDeleteIndex rejected | reason: index 0 out of range, list size: 0
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter ratio:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter date:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter ratio:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readRatio unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter ratio:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter date:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readFutureDate unsuccessful | reason: date input is not a future date
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter date:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readMoney unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter ratio:
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 0, formatted: $0.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 12250, formatted: $12,250.00
+[2026-03-31 03:18:17] [INFO] seedu.duke.CommandHandler - formatMoney succeeded | amount: 10250.5, formatted: $10,250.50
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter ratio:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readRatio unsuccessful | reason: out of specified bounds
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter ratio:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter ratio:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter date:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readFutureDate unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter date:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount:
+[2026-03-31 03:18:17] [WARNING] seedu.duke.CommandHandler - readMoney unsuccessful | reason: invalid formatting
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount:
+[2026-03-31 03:18:17] [INFO] seedu.duke.ui.Ui - Displaying prompt to user: Enter amount:
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit10272244903995750778/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit1850061267750518397/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit1850061267750518397/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 1one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit13347546319819069696/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit16033370304280116387/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit16033370304280116387/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 1one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 2 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit16033370304280116387/monthly_archives/Month2
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 2 archived successfully with 1one-off expenses and 1 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit8413453909196183867/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit7701107211200207565/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit5257759375608342563/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit8560553328591111587/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit8560553328591111587/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 0one-off expenses and 1 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit13222342708811920758/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit2902541311692836836/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit2902541311692836836/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 1one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit8318229553542124266/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit8318229553542124266/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 0one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit13750975529922707056/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit13750975529922707056/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 0one-off expenses and 2 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit10185173314320807801/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit964304414525091471/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit3688266799477963193/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit3688266799477963193/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 1one-off expenses and 1 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit417328251291103832/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit417328251291103832/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 1one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit10779764828454790309/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit6616083814295410218/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit5710739329599092621/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit4797028650568097551/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit4797028650568097551/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 0one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit10710265958617630639/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archiving Month 1 expenses to: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit10710265958617630639/monthly_archives/Month1
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Month 1 archived successfully with 2one-off expenses and 0 recurring expenses
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit12063717135775889167/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit16816232093954502303/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit3895333909257553653/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit16429218887497127237/monthly_archives
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.MonthlyArchive - Skipping unknown archived expense type: X | Bus | 1.80 | TRANSPORT
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit2311987877816826829/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit3128926922210487386/monthly_archives
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.MonthlyArchive - Archive directory created at: /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit18344208492979388952/monthly_archives
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.MonthlyArchive - Skipping malformed archived expense line: this line is malformed
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - No save file found. Starting fresh.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit5460118369537154360/order_test.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit1427319839511944225/empty_lists.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.Storage - Skipping corrupted/invalid line: E | Coffee | NOT_A_NUMBER | FOOD | 1 | Reason: Character N is neither a decimal digit number, decimal point, nor "e" notation exponential mark.
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.Storage - Skipping corrupted/invalid line: E | OnlyName | Reason: Character O is neither a decimal digit number, decimal point, nor "e" notation exponential mark.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit12789953768730346807/large_data.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit10107391884677137001/test_data.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.Storage - Skipping corrupted/invalid line: P | OldUser | 3000 | 500 | 20000 | 0.5 | 2026-03-30 | Reason: Deadline must be in the future
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit12330099392043792073/autosave_test.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit12330099392043792073/autosave_test.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Saving financial data to /var/folders/hj/ss0l6gjj34z8z8tdjmsj219w0000gn/T/junit12330099392043792073/autosave_test.txt
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.Storage - Save successful.
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.Storage - Unknown record type: X
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: Nick
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.SummaryReport - Monthly surplus is non-positive; cannot estimate completion.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: Nick
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.SummaryReport - Monthly surplus is non-positive; cannot estimate completion.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Distance is zero or negative. Goal marked as reached.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: Nick
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: Nick
+[2026-03-31 03:18:17] [WARNING] seedu.duke.data.SummaryReport - BTO goal is zero; percentage set to 0.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Distance is zero or negative. Goal marked as reached.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: Nick
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Distance is zero or negative. Goal marked as reached.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: Nick
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Distance is zero or negative. Goal marked as reached.
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: friend
+[2026-03-31 03:18:17] [INFO] seedu.duke.data.SummaryReport - Generating SummaryReport for user: Nick

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -116,8 +116,10 @@ public class Ui {
         printLine("Profile & Goal Management");
         printLine("'sort'   <keyword> - sort the expenditure list by category or recency " +
                 "(e.g sort recent, sort category)");
-        printLine("'savings' - add a surplus amount to your existing savings");
-        printLine("'save'   - archive current month's expenses and advance to next month");
+        printLine("'savings'   - add a surplus amount to your existing savings");
+        printLine("'allowance' - update your monthly allowance");
+        printLine("'ratio'     - update your BTO contribution ratio (0.0 to 1.0)");
+        printLine("'save'      - archive current month's expenses and advance to next month");
         printLine("'clear'   - wipe all current expenses from the list");
         printLine("'reset'   - wipes all profile data and expenses to start fresh.");
         printLine("");

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -49,8 +49,10 @@ Daily Transaction Commands
 
 Profile & Goal Management
 'sort'   <keyword> - sort the expenditure list by category or recency (e.g sort recent, sort category)
-'savings' - add a surplus amount to your existing savings
-'save'   - archive current month's expenses and advance to next month
+'savings'   - add a surplus amount to your existing savings
+'allowance' - update your monthly allowance
+'ratio'     - update your BTO contribution ratio (0.0 to 1.0)
+'save'      - archive current month's expenses and advance to next month
 'clear'   - wipe all current expenses from the list
 'reset'   - wipes all profile data and expenses to start fresh.
 


### PR DESCRIPTION
## Summary                                                                    
  - Added **Managing Profile** section to Developer Guide: covers               
  `BtoCalculator` formula and                                                   
    calculation logic, initial setup flow (`performInitialSetup`), runtime      
  profile update commands                                                 
    (`allowance`, `savings`, `ratio`), and BTO Summary Report metrics table     
  - Added manual test cases in DG (Section 7.1) for `allowance`, `savings`,     
  `ratio`, and `summary`                                                        
  - Added missing `allowance` and `ratio` command sections to User Guide with   
  format, example,                                                              
    expected output, and notes                                                  
  - Updated UG Features list and Command Summary table to include `allowance`   
  and `ratio`                                                                   
  - Added `allowance` and `ratio` to the in-app `help` message                  
  (`Ui.showHelpMessage`)                                                        
  - Fixed malformed code block in UG `help` section (duplicate UG header was    
  accidentally pasted                                                           
    inside the code fence)                                                      
  - Removed duplicate second half of UserGuide.md caused by a bad merge conflict
   resolution     