### PR TITLE
Fix crash bugs and data integrity issues across core data classes

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -440,9 +440,11 @@ The data is stored in a plain-text file using a pipe-delimited format. Each line
 identifier that determines how the line is parsed:
 | Prefix | Record Type      | Format                                                              |
 |--------|------------------|---------------------------------------------------------------------|
-| `P`    | Profile          | `P \| Name \| Allowance \| Savings \| BtoGoal \| Ratio \| Deadline \| CurrentMonth` |
+| `P`    | Profile          | `P \| Name \| Allowance \| Savings \| BtoGoal \| Ratio \| Deadline \| CurrentMonth \| HousePrice` |
 | `E`    | One-off Expense  | `E \| Name \| Amount \| Category \| InsertionOrder`                |
 | `R`    | Recurring Expense| `R \| Name \| Amount \| Category`                                  |
+
+> **Note:** `HousePrice` is written as `null` if the user has not set a house price. The `Name` field in `P` and `E` lines cannot contain the `|` character, as it is reserved as the field delimiter.
 
 Lines that do not match any known prefix, or that are too short to be parsed safely, are silently skipped
 with a `WARNING`-level log entry. This ensures that a single corrupted line does not abort the entire load.
@@ -452,7 +454,7 @@ with a `WARNING`-level log entry. This ensures that a single corrupted line does
 The object diagram below shows a concrete snapshot of the application's in-memory state after
 `Storage#load()` has successfully parsed the following `fintrack.txt` file:
 ```
-P | Alice | 2000.00 | 5000.00 | 25000.00 | 0.50 | 2028-10-24 | 3
+P | Alice | 2000.00 | 5000.00 | 25000.00 | 0.50 | 2028-10-24 | 3 | null
 E | Lunch | 5.50 | FOOD | 0
 E | Bus fare | 1.80 | TRANSPORT | 1
 R | Netflix | 10.90 | ENTERTAINMENT
@@ -462,8 +464,9 @@ R | Netflix | 10.90 | ENTERTAINMENT
 
 This snapshot illustrates three key design points:
 
-1. **All seven Profile fields are restored** — name, allowance, savings, BTO goal, ratio, deadline,
-   and the optional `currentMonth` field are all populated from the `P` line.
+1. **All eight Profile fields are restored** — name, allowance, savings, BTO goal, ratio, deadline,
+   `currentMonth`, and the optional `housePrice` field are all populated from the `P` line.
+   `housePrice` is written as `null` when not set and skipped during load.
 2. **Insertion order is preserved** — `e1` has `insertionOrder = 0` and `e2` has
    `insertionOrder = 1`, meaning a subsequent `sort recent` command will restore this exact sequence.
 3. **Recurring and one-off expenses are held separately** — `expenseList` and `recurringList` are
@@ -546,8 +549,9 @@ each line's parse logic in a `try-catch` block so one bad line cannot corrupt th
 
 **Why pipe (`|`) as a delimiter instead of a comma?**
 Expense names entered by users may naturally contain commas (e.g., `"rice, chicken"`), which would break
-a CSV-style parser. The pipe character is unlikely to appear in any of the stored fields, making it a
-safer choice without requiring any escape logic.
+a CSV-style parser. The pipe character is explicitly rejected in user-facing name fields (expense names
+and the user's own name) at the input layer, guaranteeing it never appears as data and making it a safe
+delimiter without requiring any escape logic.
 
 **Future enhancement — JSON format (post-v2.1)**
 A planned future improvement is to migrate the storage format to JSON using a library such as Gson. This
@@ -640,6 +644,7 @@ prompted to establish a valid profile before testing profile-dependent commands.
    5. Test case: `add lunch -1 FOOD` Expected: Error shown for negative amount. No expense added.
    6. Test case: `add lunch abc FOOD` Expected: Error shown for invalid amount format. No expense added.
    7. Test case: `add lunch 5 HELLO` Expected: Error shown for invalid category. No expense added.
+   8. Test case: `add rent | utilities 100 UTILITIES` Expected: Error shown for reserved `|` character in name. No expense added.
 2. **Deleting a one-off expense**
    1. Prerequisites: At least one expense exists in the list.
    2. Test case: `delete 1` Expected: First expense removed. Total expenditure updated.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,6 +131,7 @@ Month 1 Total: $25
 <b>NOTE:</b>
 - The keyword `recurring` is optional.
 - If omitted, the expense will be treated as a one-off expense.
+- Expense name cannot contain the `|` character, as it is reserved as the file delimiter.
 
 ### Listing all entries: ```list```
 Shows a consolidated view of all your recorded expenses, neatly categorized by recurring commitments, previous months' 
@@ -220,7 +221,7 @@ Recurring Total: $0
 - Use `list` to view recurring expenses and their indices.  
 
 ### View financial summary: ```summary```
-Generates a comprehensive financial report based on your profile and current spending habits. Calculates your monthly 
+Generates a comprehensive financial report based on your profile and current spending habits. Calculates your monthly
 surplus, distance to your goal, and provides an estimate of how many months it will take to secure your downpayment.
 The Readiness Level reflects your percentage progress toward your BTO goal, ranging from `BARELY STARTED` to `READY`.<br>
 <b>Format:</b> ```summary``` <br>
@@ -296,7 +297,7 @@ FinTrackPro data is saved in the hard disk automatically after any command that 
 <b>Warning:</b><br> Advanced users can modify fintrack.txt directly. However, if the format is corrupted, FinTrackPro will safely skip the corrupted lines to prevent the app from crashing.
 <b>Expected Output:</b>
 ```
-P | Jairus | 1500 | 1000 | 18375.00 | 0.7 | 2028-10-10 | 1
+P | Jairus | 1500 | 1000 | 18375.00 | 0.7 | 2028-10-10 | 1 | null
 E | Chicken Rice | 7.3 | FOOD | 1
 E | Pizza | 10 | FOOD | 0
 E | Game | 12 | ENTERTAINMENT | 4
@@ -319,6 +320,7 @@ R | Netflix | 30 | ENTERTAINMENT
 | `0.7`        | contribution ratio | user is paying **70%** of the BTO cost                |
 | `2028-10-10` | deadline           | goal date (ISO format `YYYY-MM-DD`)                   |
 | `1`          | current month      | user is currently tracking month **1** of their data  |
+| `null`       | house price        | total BTO flat price; `null` if not set               |
 
 **Expenditure (`E`)**
 

--- a/src/main/java/seedu/duke/CommandHandler.java
+++ b/src/main/java/seedu/duke/CommandHandler.java
@@ -194,6 +194,11 @@ public class CommandHandler {
             throw new InvalidAmountException("Expense name cannot be empty.\n");
         }
 
+        if (name.contains("|")) {
+            logger.warning("handleAdd rejected | reason: expense name contains reserved character '|'");
+            throw new InvalidAmountException("Expense name cannot contain the '|' character.\n");
+        }
+
         if (!Category.isValid(categoryString)) {
             logger.warning("handleAdd rejected | reason: invalid category " + categoryString);
             throw new InvalidCategoryException("Invalid category! Valid categories: " +
@@ -321,7 +326,7 @@ public class CommandHandler {
         assert in != null : "Scanner should not be null";
 
         ui.printLine("WARNING: This will permanently delete ALL one-off expenses. Are you sure? (Input Y to clear)");
-        String response = in.nextLine().trim().toLowerCase();
+        String response = ui.readLine(in, "").trim().toLowerCase();
 
         if (response.equals("y")) {
             expenseList.clear();
@@ -453,7 +458,7 @@ public class CommandHandler {
         assert in != null : "Scanner should not be null";
 
         ui.printLine("WARNING: This will wipe your profile and ALL expenses. Type 'Y' to continue: ");
-        String response = in.nextLine().trim().toLowerCase();
+        String response = ui.readLine(in, "").trim().toLowerCase();
 
         if (response.equals("y")) {
             // Reset in-memory objects

--- a/src/main/java/seedu/duke/FinTrackPro.java
+++ b/src/main/java/seedu/duke/FinTrackPro.java
@@ -179,8 +179,18 @@ public class FinTrackPro {
         logState("setup.start", "collect name, finances and deadline", "scannerReady=true");
 
         // 1. Name handling
-        String name = ui.readLine(in, "What is your name?");
-        name = name.trim().isEmpty() ? "friend" : name.trim();
+        String name;
+        while (true) {
+            name = ui.readLine(in, "What is your name?").trim();
+            if (name.contains("|")) {
+                ui.printLine("Name cannot contain the '|' character. Try again.");
+                continue;
+            }
+            if (name.isEmpty()) {
+                name = "friend";
+            }
+            break;
+        }
         logState("setup.name.captured", "collect current savings", "name=" + name);
 
         ui.printLine("");

--- a/src/main/java/seedu/duke/FinTrackPro.java
+++ b/src/main/java/seedu/duke/FinTrackPro.java
@@ -421,8 +421,11 @@ public class FinTrackPro {
                     totalAllMonths = totalAllMonths.add(monthTotal);
                 }
             } catch (IOException e) {
-                logger.log(java.util.logging.Level.WARNING, 
+                logger.log(java.util.logging.Level.WARNING,
                     "Failed to load archived expenses for Month " + month, e);
+            } catch (NumberFormatException e) {
+                logger.log(java.util.logging.Level.WARNING,
+                    "Corrupted amount in archive for Month " + month + ": " + e.getMessage(), e);
             }
         }
 

--- a/src/main/java/seedu/duke/data/Expense.java
+++ b/src/main/java/seedu/duke/data/Expense.java
@@ -31,7 +31,7 @@ public class Expense {
         assert amount.compareTo(BigDecimal.ZERO) >= 0 : "Expense amount must be non-negative";
         //Invariant: Category Added should not be null
         assert category != null : "Expense category should not be null";
-        //Invariant: Insertion order should be more than 0
+        //Invariant: Insertion order must be non-negative (0 is valid for the first item)
         assert insertionOrder >= 0 : "Insertion order must be non-negative";
 
         this.name = name;

--- a/src/main/java/seedu/duke/data/ExpenseList.java
+++ b/src/main/java/seedu/duke/data/ExpenseList.java
@@ -63,6 +63,9 @@ public class ExpenseList {
      */
     // Used by Storage only — preserves original insertion order from file
     public void add(String name, BigDecimal amount, Category category, int insertionOrder) {
+        assert name != null && !name.isBlank() : "Expense name should not be null or blank.";
+        assert amount != null : "Expense amount should not be null.";
+        assert category != null : "Expense category should not be null.";
         assert insertionOrder >= 0 : "Insertion order should be non-negative";
         Expense expense = new Expense(name, amount, category, insertionOrder);
         expenses.add(expense);

--- a/src/main/java/seedu/duke/data/Profile.java
+++ b/src/main/java/seedu/duke/data/Profile.java
@@ -41,6 +41,8 @@ public class Profile {
         assert housePrice != null && housePrice.compareTo(BigDecimal.ZERO) >= 0
                 : "House price cannot be null or negative";
         this.housePrice = housePrice;
+        BtoCalculator calc = new BtoCalculator(this.housePrice, this.contributionRatio);
+        this.btoGoal = calc.yourShare;
     }
 
     /**
@@ -71,7 +73,6 @@ public class Profile {
      */
     public void setDeadline(LocalDate deadline) {
         assert deadline != null : "Deadline cannot be null";
-        assert deadline.isAfter(LocalDate.now()) : "Deadline must be in the future";
         this.deadline = deadline;
     }
 
@@ -136,6 +137,7 @@ public class Profile {
      */
     public void setCurrentSavings(BigDecimal currentSavings) {
         assert currentSavings != null : "Current savings cannot be null";
+        assert currentSavings.compareTo(BigDecimal.ZERO) >= 0 : "Current savings cannot be negative";
         this.currentSavings = currentSavings;
     }
 
@@ -210,5 +212,7 @@ public class Profile {
         this.currentSavings = BigDecimal.ZERO;
         this.contributionRatio = new BigDecimal("0.5");
         this.currentMonth = 1;
+        this.housePrice = null;
+        this.deadline = LocalDate.now();
     }
 }

--- a/src/main/java/seedu/duke/data/RecurringExpenseList.java
+++ b/src/main/java/seedu/duke/data/RecurringExpenseList.java
@@ -23,6 +23,7 @@ public class RecurringExpenseList {
      * @return removed recurring expense
      */
     public RecurringExpense delete(int indexInList) {
+        assert isValidIndex(indexInList) : "Index " + indexInList + " is out of bounds";
         int indexToDelete = indexInList - 1;
         return recurringExpenses.remove(indexToDelete);
     }
@@ -82,6 +83,7 @@ public class RecurringExpenseList {
      */
     public void clear() {
         recurringExpenses.clear();
+        assert recurringExpenses.isEmpty() : "Recurring expense list should be empty after clear";
     }
     /**
      * Returns all recurring expenses whose name or category contains the given keyword.

--- a/src/main/java/seedu/duke/data/Storage.java
+++ b/src/main/java/seedu/duke/data/Storage.java
@@ -54,14 +54,15 @@ public class Storage {
 
         try (FileWriter fw = new FileWriter(filePath)) {
             // Save Profile (P)
-            fw.write(String.format("P | %s | %s | %s | %s | %s | %s | %d%n",
+            fw.write(String.format("P | %s | %s | %s | %s | %s | %s | %d | %s%n",
                     profile.getName(),
                     profile.getMonthlyAllowance(),
                     profile.getCurrentSavings(),
                     profile.getBtoGoal(),
                     profile.getContributionRatio(),
                     profile.getDeadline(),
-                    profile.getCurrentMonth()));
+                    profile.getCurrentMonth(),
+                    profile.getHousePrice() != null ? profile.getHousePrice() : "null"));
 
             // Save Expenses (E)
             for (int i = 0; i < expenseList.size(); i++) {
@@ -171,6 +172,9 @@ public class Storage {
 
         if (parts.length >= 8) {
             profile.setCurrentMonth(Integer.parseInt(parts[7]));
+        }
+        if (parts.length >= 9 && !"null".equals(parts[8].trim())) {
+            profile.setHousePrice(new BigDecimal(parts[8].trim()));
         }
     }
 

--- a/src/main/java/seedu/duke/data/SummaryReport.java
+++ b/src/main/java/seedu/duke/data/SummaryReport.java
@@ -145,7 +145,11 @@ public class SummaryReport {
             return "Infinite (Surplus is $0 or negative!)";
         }
 
-        int months = distance.divide(monthlySurplus, 0, RoundingMode.CEILING).intValue();
+        BigDecimal monthsBig = distance.divide(monthlySurplus, 0, RoundingMode.CEILING);
+        if (monthsBig.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) > 0) {
+            return "A very long time (goal is too far away)";
+        }
+        int months = monthsBig.intValue();
 
         assert months >= 0 : "Estimated months should be a positive value";
         return months + " months";

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -174,6 +174,9 @@ public class Ui {
         if (period.getDays() > 0) {
             monthsLeft++;
         }
+        if (monthsLeft < 0) {
+            monthsLeft = 0;
+        }
 
         assert monthsLeft >= 0 : "Months left should not be negative";
 

--- a/src/main/java/seedu/duke/util/InputUtil.java
+++ b/src/main/java/seedu/duke/util/InputUtil.java
@@ -72,9 +72,6 @@ public class InputUtil {
      *
      * <p>This method repeatedly prompts until valid input is received.</p>
      *
-     * <p>Note: The returned value represents 2.5% of the entered amount
-     * (calculated as amount × 0.025).</p>
-     *
      * @param ui UI component used for displaying prompts and messages.
      * @param in Scanner used to read user input.
      * @param prompt Prompt message shown to the user.

--- a/src/test/java/seedu/duke/ExpenseTest.java
+++ b/src/test/java/seedu/duke/ExpenseTest.java
@@ -3,6 +3,7 @@ package seedu.duke;
 import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import seedu.duke.data.Expense;
 import seedu.duke.category.Category;
 
@@ -58,5 +59,41 @@ public class ExpenseTest {
         Expense expense = new Expense("lunch", new BigDecimal("12.50"), Category.fromString("FOOD"), 0);
 
         assertEquals(0, expense.getInsertionOrder());
+    }
+
+    @Test
+    void constructor_nullName_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new Expense(null, new BigDecimal("10.00"), Category.fromString("FOOD"), 1));
+    }
+
+    @Test
+    void constructor_blankName_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new Expense("   ", new BigDecimal("10.00"), Category.fromString("FOOD"), 1));
+    }
+
+    @Test
+    void constructor_nullAmount_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new Expense("lunch", null, Category.fromString("FOOD"), 1));
+    }
+
+    @Test
+    void constructor_negativeAmount_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new Expense("lunch", new BigDecimal("-1.00"), Category.fromString("FOOD"), 1));
+    }
+
+    @Test
+    void constructor_nullCategory_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new Expense("lunch", new BigDecimal("10.00"), null, 1));
+    }
+
+    @Test
+    void constructor_negativeInsertionOrder_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new Expense("lunch", new BigDecimal("10.00"), Category.fromString("FOOD"), -1));
     }
 }

--- a/src/test/java/seedu/duke/RecurringExpenseListTest.java
+++ b/src/test/java/seedu/duke/RecurringExpenseListTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -208,5 +209,45 @@ public class RecurringExpenseListTest {
         ArrayList<RecurringExpense> matches = recurringExpenseList.findMatches("transport");
 
         assertTrue(matches.isEmpty());
+    }
+
+    /**
+     * Verifies that {@code getTotal()} returns zero on an empty list.
+     */
+    @Test
+    void getTotal_emptyList_returnsZero() {
+        assertEquals(BigDecimal.ZERO, recurringExpenseList.getTotal());
+    }
+
+    /**
+     * Verifies that deleting with index 0 throws AssertionError (1-based indexing).
+     */
+    @Test
+    void delete_invalidIndexZero_throwsAssertionError() {
+        recurringExpenseList.add(
+                new RecurringExpense("Netflix", new BigDecimal("30.00"), Category.fromString("ENTERTAINMENT"))
+        );
+
+        assertThrows(AssertionError.class, () -> recurringExpenseList.delete(0));
+    }
+
+    /**
+     * Verifies that deleting with an index beyond the list size throws AssertionError.
+     */
+    @Test
+    void delete_invalidIndexBeyondSize_throwsAssertionError() {
+        recurringExpenseList.add(
+                new RecurringExpense("Netflix", new BigDecimal("30.00"), Category.fromString("ENTERTAINMENT"))
+        );
+
+        assertThrows(AssertionError.class, () -> recurringExpenseList.delete(2));
+    }
+
+    /**
+     * Verifies that deleting from an empty list throws AssertionError.
+     */
+    @Test
+    void delete_emptyList_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> recurringExpenseList.delete(1));
     }
 }

--- a/src/test/java/seedu/duke/RecurringExpenseTest.java
+++ b/src/test/java/seedu/duke/RecurringExpenseTest.java
@@ -7,6 +7,7 @@ import seedu.duke.data.RecurringExpense;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for {@link RecurringExpense}.
@@ -53,5 +54,35 @@ public class RecurringExpenseTest {
                 new RecurringExpense("Netflix", new BigDecimal("30.00"), Category.fromString("ENTERTAINMENT"));
 
         assertEquals("[RECURRING][ENTERTAINMENT] Netflix $30.00", recurringExpense.toString());
+    }
+
+    @Test
+    void constructor_nullName_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new RecurringExpense(null, new BigDecimal("30.00"), Category.fromString("ENTERTAINMENT")));
+    }
+
+    @Test
+    void constructor_blankName_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new RecurringExpense("   ", new BigDecimal("30.00"), Category.fromString("ENTERTAINMENT")));
+    }
+
+    @Test
+    void constructor_nullAmount_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new RecurringExpense("Netflix", null, Category.fromString("ENTERTAINMENT")));
+    }
+
+    @Test
+    void constructor_negativeAmount_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new RecurringExpense("Netflix", new BigDecimal("-1.00"), Category.fromString("ENTERTAINMENT")));
+    }
+
+    @Test
+    void constructor_nullCategory_throwsAssertionError() {
+        assertThrows(AssertionError.class, () ->
+                new RecurringExpense("Netflix", new BigDecimal("30.00"), null));
     }
 }

--- a/src/test/java/seedu/duke/StorageTest.java
+++ b/src/test/java/seedu/duke/StorageTest.java
@@ -3,7 +3,6 @@ package seedu.duke;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import seedu.duke.category.Category;
 import seedu.duke.data.ExpenseList;
@@ -101,18 +100,17 @@ class StorageTest {
     }
 
     @Test
-    void profile_setDeadlinePastOrToday_throwsAssertionError() {
+    void profile_setDeadlinePastOrToday_isAccepted() {
         Profile profile = new Profile();
 
-        // Testing Today
-        assertThrows(AssertionError.class, () -> {
-            profile.setDeadline(LocalDate.now());
-        }, "Assertion should trigger for current date");
+        // Past and today dates are accepted by the setter; validation is enforced at input via InputUtil
+        LocalDate today = LocalDate.now();
+        profile.setDeadline(today);
+        assertEquals(today, profile.getDeadline());
 
-        // Testing Past
-        assertThrows(AssertionError.class, () -> {
-            profile.setDeadline(LocalDate.now().minusDays(1));
-        }, "Assertion should trigger for past dates");
+        LocalDate past = LocalDate.now().minusDays(1);
+        profile.setDeadline(past);
+        assertEquals(past, profile.getDeadline());
     }
 
     @Test

--- a/src/test/java/seedu/duke/SummaryReportTest.java
+++ b/src/test/java/seedu/duke/SummaryReportTest.java
@@ -12,7 +12,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SummaryReportTest {
     @Test
@@ -259,18 +258,17 @@ public class SummaryReportTest {
     }
 
     @Test
-    void profile_setDeadlinePastOrToday_throwsAssertionError() {
+    void profile_setDeadlinePastOrToday_isAccepted() {
         Profile profile = new Profile();
 
-        // Testing Today (assuming your assertion requires strictly AFTER today)
-        assertThrows(AssertionError.class, () -> {
-            profile.setDeadline(LocalDate.now());
-        });
+        // Past and today dates are accepted by the setter; validation is enforced at input via InputUtil
+        LocalDate today = LocalDate.now();
+        profile.setDeadline(today);
+        assertEquals(today, profile.getDeadline());
 
-        // Testing Past
-        assertThrows(AssertionError.class, () -> {
-            profile.setDeadline(LocalDate.now().minusDays(1));
-        });
+        LocalDate past = LocalDate.now().minusDays(1);
+        profile.setDeadline(past);
+        assertEquals(past, profile.getDeadline());
     }
 
     @Test

--- a/src/test/java/seedu/duke/SummaryReportTest.java
+++ b/src/test/java/seedu/duke/SummaryReportTest.java
@@ -272,6 +272,20 @@ public class SummaryReportTest {
     }
 
     @Test
+    void summaryReport_pastDeadline_doesNotCrash() {
+        Profile profile = new Profile();
+        profile.setBtoGoal(new BigDecimal("10000"));
+        profile.setCurrentSavings(new BigDecimal("2000"));
+        profile.setMonthlyAllowance(new BigDecimal("4000"));
+        profile.setDeadline(LocalDate.now().minusMonths(3));
+
+        // Should not throw AssertionError — monthsLeft clamped to 1 in SummaryReport
+        SummaryReport report = new SummaryReport(profile, new ExpenseList(), new RecurringExpenseList());
+
+        assertEquals(new BigDecimal("8000.00"), report.monthlyRequired);
+    }
+
+    @Test
     void summaryReport_zeroExpenditure_surplusEqualsAllowance() {
         Profile profile = new Profile();
         profile.setMonthlyAllowance(new BigDecimal("2500"));

--- a/src/test/java/seedu/duke/data/ProfileTest.java
+++ b/src/test/java/seedu/duke/data/ProfileTest.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProfileTest {
@@ -77,6 +78,11 @@ public class ProfileTest {
         BigDecimal large = new BigDecimal("999999999.99");
         profile.setCurrentSavings(large);
         assertEquals(large, profile.getCurrentSavings());
+    }
+
+    @Test
+    public void setCurrentSavings_negativeValue_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> profile.setCurrentSavings(new BigDecimal("-100")));
     }
 
     /**
@@ -163,6 +169,20 @@ public class ProfileTest {
         assertThrows(AssertionError.class, () -> profile.setHousePrice(new BigDecimal("-1")));
     }
 
+    @Test
+    public void setHousePrice_withDefaultRatio_recalculatesBtoGoal() {
+        profile.setHousePrice(new BigDecimal("400000"));
+        assertEquals(new BigDecimal("10500.00"), profile.getBtoGoal());
+    }
+
+    @Test
+    public void setHousePrice_afterChanging_recalculatesBtoGoal() {
+        profile.setContributionRatio(new BigDecimal("0.5"));
+        profile.setHousePrice(new BigDecimal("400000"));
+        profile.setHousePrice(new BigDecimal("500000"));
+        assertEquals(new BigDecimal("13125.00"), profile.getBtoGoal());
+    }
+
     /**
      * Unit tests for btoGoal.
      */
@@ -219,13 +239,17 @@ public class ProfileTest {
     }
 
     @Test
-    public void setDeadline_pastDate_throwsAssertionError() {
-        assertThrows(AssertionError.class, () -> profile.setDeadline(LocalDate.of(2020, 1, 1)));
+    public void setDeadline_pastDate_isAccepted() {
+        LocalDate past = LocalDate.of(2020, 1, 1);
+        profile.setDeadline(past);
+        assertEquals(past, profile.getDeadline());
     }
 
     @Test
-    public void setDeadline_today_throwsAssertionError() {
-        assertThrows(AssertionError.class, () -> profile.setDeadline(LocalDate.now()));
+    public void setDeadline_today_isAccepted() {
+        LocalDate today = LocalDate.now();
+        profile.setDeadline(today);
+        assertEquals(today, profile.getDeadline());
     }
 
     @Test
@@ -269,6 +293,8 @@ public class ProfileTest {
         profile.setMonthlyAllowance(new BigDecimal("2000"));
         profile.setBtoGoal(new BigDecimal("50000"));
         profile.setContributionRatio(new BigDecimal("0.7"));
+        profile.setHousePrice(new BigDecimal("400000"));
+        profile.setDeadline(LocalDate.now().plusYears(2));
         profile.advanceMonth();
 
         profile.reset();
@@ -279,5 +305,7 @@ public class ProfileTest {
         assertEquals(BigDecimal.ZERO, profile.getBtoGoal());
         assertEquals(new BigDecimal("0.5"), profile.getContributionRatio());
         assertEquals(1, profile.getCurrentMonth());
+        assertNull(profile.getHousePrice());
+        assertEquals(LocalDate.now(), profile.getDeadline());
     }
 }


### PR DESCRIPTION
## Summary
  ### Bug Fixes
  - Fix AssertionError crash in `summary` when the user's deadline has passed
  - Fix NoSuchElementException crash in `clear`/`reset` when stdin is closed (EOF) during confirmation prompt
  - Fix silent data loss when expense names or user name contain `|`, which corrupted the save file and caused profile/expenses to
  disappear on restart
  - Fix integer overflow in estimated months display for very large BTO distances
  - Fix uncaught NumberFormatException in `list` command when loading corrupted archive files
  - Fix non-negative assertion missing from `Profile.setCurrentSavings()`
  - Fix `Profile.setHousePrice()` not recalculating `btoGoal` via `BtoCalculator`
  - Fix `Profile.reset()` not resetting `housePrice` and `deadline` fields
  - Fix `housePrice` not being persisted to `fintrack.txt` (added as 9th field)
  - Fix wrong comment on `insertionOrder` assertion in `Expense`
  - Add missing pre-condition assertions to `ExpenseList.add()` (4-arg Storage variant)
  - Add bounds guard to `RecurringExpenseList.delete()` and post-condition to `clear()`
  - Remove false Javadoc in `InputUtil.readMoney` claiming it returns 2.5% of input

  ### Tests Added
  - AssertionError tests for invalid constructor inputs in `Expense`, `RecurringExpense`
  - Invalid-index delete tests and empty-list total test for `RecurringExpenseList`
  - Past-deadline safety test for `SummaryReport`

  ### Documentation
  - UG: Add `|` restriction note to `add` command
  - UG: Update `fintrack.txt` example and Profile table to include `housePrice` field
  - DG: Update Data Persistence Format table and example to include `housePrice`
  - DG: Update field count ("seven" → "eight") and pipe delimiter design rationale
  - DG: Add `|` in expense name as a manual test case